### PR TITLE
run docker containers in detached mode

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ fi
 
 # Start services in detached mode
 echo "Starting services..."
-$DOCKER_COMPOSE up --build
+$DOCKER_COMPOSE up -d --build
 
 # Wait for Ollama to be ready
 echo "Waiting for Ollama to start..."
@@ -55,4 +55,4 @@ echo ""
 echo "Press Ctrl+C to stop all services"
 
 # Follow logs
-$DOCKER_COMPOSE logs
+$DOCKER_COMPOSE logs -f


### PR DESCRIPTION
- The run script was running docker services in foreground which caused the script to block and not run anything below `docker compose up`
- Because of this, the llama model was not being pulled and the app didn't work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services now start in the background, freeing your terminal immediately.
  * Automatic real-time log streaming for easier monitoring during startup.

* **Chores**
  * Updated run script to improve startup flow and developer experience by combining detached startup with follow-along logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->